### PR TITLE
correction gha : edit tag on values about input and not branch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -69,7 +69,7 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "image_version=$(if [ "${{ github.ref_name }}" = "main" ]; then echo "latest"; else echo "develop"; fi)" >> $GITHUB_OUTPUT
+          echo "image_version=$(if [ "${{ github.event.inputs.environment }}" = "prod" ]; then echo "latest"; else echo "develop"; fi)" >> $GITHUB_OUTPUT
 
           sed -i "s/tag: \"latest\"/tag: \"$image_version\"/" values.yaml
     

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,7 +36,7 @@ jobs:
       - id: auth
         uses: 'google-github-actions/auth@v2'
         with:
-          workload_identity_provider: 'projects/161911340849/locations/global/workloadIdentityPools/filrouge-formation/providers/my-oidc-github-provider'
+          workload_identity_provider: 'projects/161911340849/locations/global/workloadIdentityPools/filrouge-formation/providers/oidc-github-provider'
           service_account: 'filrouge-main-sa@filrouge-452215.iam.gserviceaccount.com'
 
 


### PR DESCRIPTION
This pull request includes a small but important change to the deployment workflow file. The change modifies the logic for setting the `image_version` based on the `environment` input rather than the `ref_name`.

* [`.github/workflows/deploy.yaml`](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L72-R72): Changed the condition to set `image_version` to "latest" if the `environment` input is "prod", otherwise it sets it to "develop".