### PR TITLE
correction gha : delete set values in deploy workflow but in terraform file main

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -65,20 +65,6 @@ jobs:
 
 
 
-      - name: Set the value of the image version for values.yaml
-        id: vars
-        shell: bash
-        run: |
-          echo "image_version=$(if [ "${{ github.event.inputs.environment }}" = "prod" ]; then echo "latest"; else echo "develop"; fi)" >> $GITHUB_OUTPUT
-
-          sed -i "s/tag: \"latest\"/tag: \"$image_version\"/" values.yaml
-    
-          echo "Updated values.yaml:"
-          cat values.yaml
-        working-directory: myproject
-
-
-
       - name: Use terraform
         uses: hashicorp/setup-terraform@v3
 
@@ -203,20 +189,6 @@ jobs:
         with:
           name: filrouge-${{ github.event.inputs.environment }}-sa
           path: ./
-
-
-
-      - name: Set the value of the image version for values.yaml
-        id: vars
-        shell: bash
-        run: |
-          echo "image_version=$(if [ "${{ github.ref_name }}" = "main" ]; then echo "latest"; else echo "develop"; fi)" >> $GITHUB_OUTPUT
-
-          sed -i "s/tag: \"latest\"/tag: \"$image_version\"/" values.yaml
-    
-          echo "Updated values.yaml:"
-          cat values.yaml
-        working-directory: myproject
 
 
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -105,6 +105,16 @@ resource "helm_release" "chart" {
   chart      = local.chart
   version    = local.chart_version
 
+  set {
+    name  = "backend.image.tag"
+    value = terraform.workspace == "dev" ? "develop" : "latest"
+  }
+
+  set {
+    name  = "frontend.image.tag"
+    value = terraform.workspace == "dev" ? "develop" : "latest"
+  }
+
   wait    = true
   timeout = 1000
 }


### PR DESCRIPTION
This pull request includes changes to the deployment workflow and Terraform configuration to streamline the image versioning process. The most important changes are the removal of redundant steps in the GitHub Actions workflow and the addition of image version settings in the Terraform configuration.

### Improvements to deployment workflow:

* [`.github/workflows/deploy.yaml`](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L68-L81): Removed steps that set the image version for `values.yaml` based on the environment or branch name. [[1]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L68-L81) [[2]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L209-L222)

### Enhancements to Terraform configuration:

* [`terraform/main.tf`](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R108-R117): Added `set` blocks to configure the `backend.image.tag` and `frontend.image.tag` based on the Terraform workspace, setting the tag to "develop" for the "dev" workspace and "latest" for others.