### PR TITLE
correction gha : edit providers name in apply job in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -179,7 +179,7 @@ jobs:
       - id: auth
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: 'projects/172767828573/locations/global/workloadIdentityPools/my-github-formation/providers/my-oidc-github-provide'
+          workload_identity_provider: 'projects/172767828573/locations/global/workloadIdentityPools/my-github-formation/providers/oidc-github-provide'
           service_account: 'filrouge-main-sa@filrouge-452215.iam.gserviceaccount.com'
 
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/deploy.yaml` file. The change updates the `workload_identity_provider` value to correct the provider name.

* [`.github/workflows/deploy.yaml`](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L182-R182): Updated the `workload_identity_provider` value from 'my-oidc-github-provide' to 'oidc-github-provide'.