### PR TITLE
correction gha : edit providers name in apply job in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -179,7 +179,7 @@ jobs:
       - id: auth
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: 'projects/172767828573/locations/global/workloadIdentityPools/my-github-formation/providers/oidc-github-provide'
+          workload_identity_provider: 'projects/172767828573/locations/global/workloadIdentityPools/my-github-formation/providers/oidc-github-provider'
           service_account: 'filrouge-main-sa@filrouge-452215.iam.gserviceaccount.com'
 
 


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/deploy.yaml` file. The change corrects the `workload_identity_provider` value to use the correct provider name.

* [`.github/workflows/deploy.yaml`](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L182-R182): Corrected the `workload_identity_provider` value from 'oidc-github-provide' to 'oidc-github-provider'.