### PR TITLE
correction gha : delete remove_default_node_pool and add destroy workflow

### DIFF
--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -1,0 +1,83 @@
+name: Destroy Workflow
+
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment'
+        required: true
+        type: choice
+        options:
+          - dev
+          - prod
+
+
+
+jobs:
+  terraform-plan:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    
+    runs-on: self-hosted
+    
+    environment: ${{ github.event.inputs.environment }}
+    
+    steps:
+
+
+
+      - name: 🔀 Checkout repository
+        uses: actions/checkout@v4
+
+
+
+      - id: auth
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/161911340849/locations/global/workloadIdentityPools/filrouge-formation/providers/oidc-github-provider'
+          service_account: 'filrouge-main-sa@filrouge-452215.iam.gserviceaccount.com'
+
+
+
+      - id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@v2
+        with:
+          secrets: |-
+            service-account:filrouge-452215/sa-${{ github.event.inputs.environment }}
+
+
+
+      - name: Setup credentials files for Terraform ${{ github.event.inputs.environment }}
+        id: credentials
+        run: |
+          echo "${{ steps.secrets.outputs.service-account }}" | base64 --decode > ./filrouge-${{ github.event.inputs.environment }}-sa.json
+          ls -la
+
+
+
+      - name: Use terraform
+        uses: hashicorp/setup-terraform@v3
+
+
+
+      - name: Terraform Init
+        id: init
+        run: terraform init -input=false
+        working-directory: terraform
+
+
+
+      - name: Terraform workspace ${{ github.event.inputs.environment }}
+        id: workspace
+        run: terraform workspace select ${{ github.event.inputs.environment }}
+        working-directory: terraform
+
+
+
+      - name: Terraform Destroy
+        id: plan
+        run: terraform destroy --auto-approve
+        continue-on-error: true
+        working-directory: terraform

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -72,9 +72,6 @@ module "gke" {
   service_account            = local.service_account
 
   deletion_protection        = false
-
-  # En ne spécifiant pas de bloc "node_pools", le module créera automatiquement un pool par défaut.
-  remove_default_node_pool = false
 }
 
 # Module configuration for Helm


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow and makes a minor change to the Terraform configuration. The most important changes include the addition of a destroy workflow and the removal of a comment in the Terraform configuration file.

### New GitHub Actions Workflow:
* [`.github/workflows/destroy.yaml`](diffhunk://#diff-0279a4ef12579f41e8d6af3b71dbb029a5785b4febe028146bd142777750677fR1-R83): Added a new workflow named "Destroy Workflow" which includes steps for checking out the repository, authenticating with Google, setting up credentials for Terraform, and running Terraform commands to destroy infrastructure.

### Terraform Configuration Update:
* [`terraform/main.tf`](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L75-L77): Removed a comment related to the default node pool creation in the GKE module configuration.