### PR TITLE
correction gha : rename job in destroy workflow

### DIFF
--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -15,7 +15,7 @@ on:
 
 
 jobs:
-  terraform-plan:
+  terraform-destroy:
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/destroy.yaml` file. The change renames the job from `terraform-plan` to `terraform-destroy`.

* [`.github/workflows/destroy.yaml`](diffhunk://#diff-0279a4ef12579f41e8d6af3b71dbb029a5785b4febe028146bd142777750677fL18-R18): Renamed job from `terraform-plan` to `terraform-destroy`.